### PR TITLE
Docker examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,17 @@ ADD $GH/wireshark/wireshark/master/manuf                $USR/wireshark/manuf
 ADD $GH/royhills/arp-scan/master/ieee-oui.txt           $USR/arp-scan/ieee-oui.txt
 ADD $GH/nmap/nmap/master/nmap-service-probes            $USR/nmap/nmap-service-probes
 
+# tcpdump is needed by scapy to replay pcaps
+RUN apk update && apk add --no-cache tcpdump
+
 # Install and configure python libraries
 COPY requirements.txt /requirements.txt
-RUN pip install --no-cache-dir -r /requirements.txt
-RUN echo 'noenum = [ Resolve(), TCP_SERVICES, UDP_SERVICES ]' >> $HOME/.scapy_startup.py
+RUN pip install --no-cache-dir -r /requirements.txt && \
+# Disable scapy DNS lookups
+echo 'noenum = [ Resolve(), TCP_SERVICES, UDP_SERVICES ]' >> $HOME/.scapy_startup.py && \
+# Create passer's cache directory for suspicious and trusted IPs
+mkdir $HOME/.passer/
+VOLUME $HOME/.passer/
 
 COPY passer.py /passer.py
 
@@ -24,6 +31,3 @@ LABEL org.opencontainers.image.title="passer"
 LABEL org.opencontainers.image.description="PASsive SERvice sniffer"
 LABEL org.opencontainers.image.url="https://github.com/activecm/passer"
 LABEL org.opencontainers.image.documentation="https://github.com/activecm/passer/blob/master/README.md"
-
-# docker build -t passer .
-# docker run --rm -it --name=passer --net=host passer


### PR DESCRIPTION
- Added a docker equivalent to each of the examples in the readme
- Added a custom bash function to make running docker examples simpler
- Updated dockerfile to include tcpdump dependency (was getting an error from scapy on reading pcaps otherwise)
- Updated dockerfile to retain trusted and suspicious IPs between runs (~/.passer/)